### PR TITLE
lose some dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,10 +9,9 @@ Description: Search and extract data from the OECD.
 License: GPL-3
 URL: https://www.github.com/expersso/oecd
 Imports:
-    XML (>= 3.98-1.1),
-    httr (>= 0.6.1),
     dplyr (>= 0.4.1),
-    rsdmx (>= 0.4-7)
+    rsdmx (>= 0.4-7),
+    xml2 (>= 0.1.2)
 Suggests:
     knitr
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ Imports:
     XML (>= 3.98-1.1),
     httr (>= 0.6.1),
     dplyr (>= 0.4.1),
-    rsdmx (>= 0.4-7),
-    stringr (>= 1.0.0)
+    rsdmx (>= 0.4-7)
 Suggests:
     knitr
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ URL: https://www.github.com/expersso/oecd
 Imports:
     XML (>= 3.98-1.1),
     httr (>= 0.6.1),
-    plyr (>= 1.8.1),
     dplyr (>= 0.4.1),
     rsdmx (>= 0.4-7),
     stringr (>= 1.0.0)

--- a/R/main.R
+++ b/R/main.R
@@ -37,18 +37,21 @@ get_datasets <- function() {
 #' blank, in which case a temporary data frame is fetched. The second option 
 #' adds a few seconds to each search query.
 #' 
+#' @param ignore.case Whether the search should be case-insensitive.
+#' Defaults to \code{TRUE}.
+#' 
 #' @return A data frame.
 #' 
 #' @seealso \code{\link{get_datasets}}
 #' 
 #' @examples
 #' #dsets <- get_datasets()
-#' #search_series("employment", dsets)
+#' #search_dataset("employment", dsets)
 #' @export
-search_dataset <- function(string, data = get_datasets()) {
+search_dataset <- function(string, data = get_datasets(), ignore.case = TRUE) {
   data %>% 
-    dplyr::filter(stringr::str_detect(description, 
-                                      stringr::regex(string, ignore.case = TRUE)))
+    dplyr::filter(grepl(string, description, ignore.case = ignore.case)) %>%
+    as.data.frame()
 }
 
 #' Get the data structure of a dataset.
@@ -97,7 +100,7 @@ get_data_structure <- function(dataset) {
         dplyr::rename("label" = label.en)
     }
     ) %>% 
-    `names<-`(stringr::str_replace(code_names, paste0("CL_", dataset, "_"), ""))
+    `names<-`(gsub(paste0("CL_", dataset, "_"), "", code_names))
   
   c("VAR_DESC" = list(variable_desc), code_list)
 }

--- a/R/main.R
+++ b/R/main.R
@@ -21,8 +21,8 @@ get_datasets <- function() {
     httr::content() %>% 
     XML::xmlToList() %>% 
     .[["KeyFamilies"]] %>% 
-    plyr::ldply(function(x) data.frame("id" = x$.attrs["id"], "description" = x$Name$text)) %>% 
-    .[, -1]  
+    lapply(function(x) dplyr::data_frame("id" = x$.attrs["id"], "description" = x$Name$text)) %>% 
+    dplyr::bind_rows()
 }
 
 #' Search codes and descriptions of available OECD series

--- a/R/main.R
+++ b/R/main.R
@@ -48,6 +48,7 @@ get_datasets <- function() {
 #' #search_dataset("employment", dsets)
 #' @export
 search_dataset <- function(string, data = get_datasets(), ignore.case = TRUE) {
+  
   data %>% 
     dplyr::filter(grepl(string, description, ignore.case = ignore.case)) %>%
     as.data.frame()
@@ -63,7 +64,7 @@ search_dataset <- function(string, data = get_datasets(), ignore.case = TRUE) {
 #' @return A list of data frames.
 #' 
 #' @examples
-#' #get_data_structure("DUR_D")
+#' \dontrun{get_data_structure("DUR_D")}
 #'
 #' @export
 get_data_structure <- function(dataset) {
@@ -196,7 +197,8 @@ get_dataset <- function(dataset, filter = NULL, start_time = NULL, end_time = NU
   }
 
   if (!is.null(start_time) && !is.null(end_time)) {
-    url_list = paste0(url_list, "?", start_time, ifelse(is.null(end_time), "", "&"), end_time)
+    url_list = paste0(url_list, "?", start_time, 
+                      ifelse(is.null(end_time), "", "&"), end_time)
   } else if (!is.null(start_time) | !is.null(end_time)) {
     url_list = paste0(url_list, "?", start_time, end_time)
   }


### PR DESCRIPTION
This PR tries to make the package lighter to install by losing some package dependencies and replacing some others:

- Removes the dependencies on `plyr` and `stringr`.
- Replaces the dependency on `httr` and `XML` with a dependency to `xml2`

Some of the code in ` get_dataset` is now a bit uglier (URL creation is done manually instead of using `httr`), but it produces exactly the same results in roughly as many lines.

Based on a few tests, replacing `XML` with `xml2` does not speed up `get_datasets` but does not slow it either. Perhaps there is a way to avoid converting the XML to list in `get_datasets`, which would definitely speed things up, but I do not understand `libxml2` very well and could not find a way to do it.

I'm pretty sure losing the first two dependencies is a good idea, because using `plyr` and `dplyr` together can create issues and because `stringr` imports `stringi`, which is heavy. I'm less sure about the second replacement.