### PR TITLE
readsdmx::read_sdmx has been way faster in downloading big datasets.

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -210,7 +210,8 @@ get_dataset <- function(dataset, filter = NULL, start_time = NULL, end_time = NU
   class(url_list) <- "url"
   
   url <- httr::build_url(url_list)
-  df <- as.data.frame(rsdmx::readSDMX(url), ...)
+  
+  df <- readsdmx::read_sdmx((url), ...)
   class(df) <- c("tbl_df", "tbl", "data.frame")
   df
 }


### PR DESCRIPTION
As I have tried to download a large dataset, I used readsdmx::read_sdmx to improve the performance of downloading and loading the dataset into R massivly. That is in line with the performance comparison on the corresponding package github page (https://github.com/mdequeljoe/readsdmx).